### PR TITLE
Entity attribute getters

### DIFF
--- a/lib/core/Component.d.ts
+++ b/lib/core/Component.d.ts
@@ -3,6 +3,7 @@ export declare abstract class Component {
     componentMethods: Array<string>;
     name: string | number;
     setAttribute: Function;
+    setAttributeGetter: Function;
     constructor(name: string | number);
     onAdded(entity: Entity): void;
     onRemoved(entity: Entity): void;

--- a/lib/core/Component.js
+++ b/lib/core/Component.js
@@ -5,6 +5,7 @@ class Component {
         // name of functions an entity gets by applying the component.
         this.componentMethods = [];
         this.setAttribute = () => { };
+        this.setAttributeGetter = () => { };
         if (typeof (name) === 'undefined') {
             throw "Component: Invalid component name";
         }

--- a/lib/core/Entity.d.ts
+++ b/lib/core/Entity.d.ts
@@ -10,6 +10,7 @@ export declare abstract class Entity {
     attributes: {
         [name: string]: any;
     };
+    attributeGetters: Array<Array<any>>;
     constructor(id: any, type: any);
     abstract initialize(data?: any): void;
     /**
@@ -19,6 +20,7 @@ export declare abstract class Entity {
      */
     addComponent(component: Component): void;
     protected setAttribute(key: string, value: any): void;
+    protected setAttributeGetter(key: string, value: Function): void;
     getComponent(componentName: any): any;
     getAttributes(): {
         [name: string]: any;

--- a/lib/core/Entity.js
+++ b/lib/core/Entity.js
@@ -4,6 +4,7 @@ class Entity {
     constructor(id, type) {
         this.componentNames = [];
         this.attributes = {};
+        this.attributeGetters = [];
         // Generate a pseudo random ID
         this.id = id;
         this.type = type;
@@ -35,16 +36,30 @@ class Entity {
         }
         // attach setAttribute to component
         component.setAttribute = this.setAttribute.bind(this);
+        component.setAttributeGetter = this.setAttributeGetter.bind(this);
         component.onAdded(this);
         this.componentNames.push(component.name);
     }
     setAttribute(key, value) {
         this.attributes[key] = value;
     }
+    setAttributeGetter(key, value) {
+        for (let i = 0; i < this.attributeGetters.length; i++) {
+            if (this.attributeGetters[i][0] === key) {
+                throw new Error(`Trying to set multiple attribute getters for the same key ${key}`);
+            }
+        }
+        this.attributeGetters.push([key, value]);
+    }
     getComponent(componentName) {
         return this.components[componentName];
     }
     getAttributes() {
+        let len = this.attributeGetters.length;
+        while (len--) {
+            const array = this.attributeGetters[len];
+            this.attributes[array[0]] = array[1]();
+        }
         return this.attributes;
     }
     // checks if the compnentName is referenced in the entity.

--- a/lib/core/System/ClientSystem.d.ts
+++ b/lib/core/System/ClientSystem.d.ts
@@ -5,7 +5,7 @@ declare abstract class ClientSystem extends System {
     readonly name: string | number;
     private client;
     protected dispatchToServer: (message: Message) => void;
-    protected dispatchProccessMessage: (payload: any) => void;
+    protected dispatchProcessMessage: (messageName: string, payload: any) => void;
     protected immediateDispatchToServer: (message: Message) => void;
     isNetworked: boolean;
     constructor(name: string | number);

--- a/lib/core/System/ClientSystem.js
+++ b/lib/core/System/ClientSystem.js
@@ -24,7 +24,7 @@ class ClientSystem extends System_1.default {
         this.client = client;
         this.messageQueue = messageQueue;
         this.messageQueue.addSystem(this);
-        this.dispatchProccessMessage = client.raiseMessage.bind(client);
+        this.dispatchProcessMessage = client.raiseMessage.bind(client);
         this.initializeEntity = entityManager.initializeEntity.bind(entityManager);
         this.destroyEntity = entityManager.destroyEntity.bind(entityManager);
         this.dispatchToServer = client.sendSystemMessage.bind(client);

--- a/lib/core/WebClient/Client.js
+++ b/lib/core/WebClient/Client.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const signals_1 = require("@gamestdio/signals");
+const Connector_1 = require("./Connector");
 class Client {
     constructor(url, token) {
         this.runningProcess = null;
@@ -27,6 +28,7 @@ class Client {
         this.hostname = url;
         this.options = {};
         this.token = token;
+        this.connector = new Connector_1.Connector();
     }
     addGameProcess(gameType, process) {
         if (gameType in this.processes) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gotti",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "description": "Full stack scalable javascript and html5 game engine.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gotti",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "description": "Full stack scalable javascript and html5 game engine.",

--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -5,6 +5,7 @@ export abstract class Component {
     public componentMethods: Array<string> = [];
     public name: string | number;
     public setAttribute: Function = () => {};
+    public setAttributeGetter: Function = () => {};
 
     constructor(name: string | number){
         if (typeof(name) === 'undefined')

--- a/src/core/System/ClientSystem.ts
+++ b/src/core/System/ClientSystem.ts
@@ -11,7 +11,7 @@ abstract class ClientSystem extends System {
     protected dispatchToServer: (message: Message) => void;
 
     // raises a message that you can register a handler from a web client using client.onProcessMessage();
-    protected dispatchProccessMessage: (payload: any) => void;
+    protected dispatchProcessMessage: (messageName: string, payload: any) => void;
 
     // sends system to message that gets processed as soon as it is received.
     protected immediateDispatchToServer: (message: Message) => void;
@@ -43,7 +43,7 @@ abstract class ClientSystem extends System {
         this.messageQueue = messageQueue;
         this.messageQueue.addSystem(this);
 
-        this.dispatchProccessMessage = client.raiseMessage.bind(client);
+        this.dispatchProcessMessage = client.raiseMessage.bind(client);
         this.initializeEntity = entityManager.initializeEntity.bind(entityManager);
         this.destroyEntity = entityManager.destroyEntity.bind(entityManager);
 

--- a/src/core/WebClient/Client.ts
+++ b/src/core/WebClient/Client.ts
@@ -48,6 +48,7 @@ export class Client {
         this.hostname = url;
         this.options = {};
         this.token = token;
+        this.connector = new Connector();
     }
 
     public addGameProcess(gameType, process: ClientProcess) {

--- a/test/core/Entity.test.ts
+++ b/test/core/Entity.test.ts
@@ -25,7 +25,7 @@ export class TestComponent extends Component {
 
 describe('Entity', function() {
     let testEntity;
-    before('Creates entity ', (done) => {
+    beforeEach('Creates entity ', (done) => {
         testEntity = new TestEntity();
         done();
     });
@@ -39,12 +39,14 @@ describe('Entity', function() {
             done();
         });
         it('throws an error if we try adding duplicate components', (done) => {
+            testEntity.addComponent(new TestComponent());
             assert.throws(() => {    testEntity.addComponent(new TestComponent()); });
             done();
         })
     });
     describe('entity.removeComponent', () => {
         it('succesfully removes component and its methods from entity', (done) => {
+            testEntity.addComponent(new TestComponent());
             testEntity.removeComponent('TEST');
             assert.ok(!('testMethod' in testEntity));
             assert.strictEqual(Object.keys(testEntity.methodsFromComponent).length, 0);
@@ -65,5 +67,25 @@ describe('Entity', function() {
             sinon.assert.calledOnce(onRemovedSpy);
             done();
         });
+    });
+    describe('entity.getAttributes()', () => {
+        it('gets attributes from components using setAttribute', (done) => {
+            let component = new TestComponent();
+            testEntity.addComponent(component);
+            component.setAttribute("test_key", "test_value");
+            const attributes = testEntity.getAttributes();
+            assert.deepStrictEqual(attributes, { "test_key": "test_value"});
+            done();
+        });
+        it("gets attributes from components using setAttributeGetter", (done) => {
+            let component = new TestComponent();
+            testEntity.addComponent(component);
+            component.setAttributeGetter("test_key", () => {
+                return "test_value"
+            });
+            const attributes = testEntity.getAttributes();
+            assert.deepStrictEqual(attributes, { "test_key": "test_value"});
+            done();
+        })
     })
 });


### PR DESCRIPTION
allows you to define inside your components a function that formats an attribute

so say you have a weapon array in your weapon component with lots of extra data not needed just to initialize a player somewhere we can set an attribute getter

defined in component - 

```
this.setAttributeGetter('weapons', () => {
   return this.weapons.map(w => w.id);
})
```

from entity -

```
var attributes = entity.getAttributes();
// attributes becomes { weapons: [1, 2, etc] }
```


