### PR TITLE
NetworkComponent(new Component()) - adds dispatchRemote method functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+coverage/
+.nyc_output
+.idea/

--- a/lib/core/Component.d.ts
+++ b/lib/core/Component.d.ts
@@ -4,7 +4,11 @@ export declare abstract class Component {
     name: string | number;
     setAttribute: Function;
     setAttributeGetter: Function;
-    constructor(name: string | number);
+    isNetworked: boolean;
+    dispatchRemote: Function;
+    onRemote: Function;
+    entityId: string | number;
+    constructor(name: string | number, isNetworked?: boolean);
     onAdded(entity: Entity): void;
     onRemoved(entity: Entity): void;
 }

--- a/lib/core/Component.js
+++ b/lib/core/Component.js
@@ -1,11 +1,14 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 class Component {
-    constructor(name) {
+    constructor(name, isNetworked = false) {
         // name of functions an entity gets by applying the component.
         this.componentMethods = [];
         this.setAttribute = () => { };
         this.setAttributeGetter = () => { };
+        this.dispatchRemote = (message) => { };
+        this.onRemote = (message) => { };
+        this.isNetworked = isNetworked;
         if (typeof (name) === 'undefined') {
             throw "Component: Invalid component name";
         }
@@ -13,6 +16,7 @@ class Component {
         this.componentMethods = Object.getOwnPropertyNames(parentObj).filter(p => {
             return p !== "constructor" && p !== "prototype" && p !== 'onAdded' && p !== 'onRemoved';
         });
+        this.entityId = parentObj.id;
         this.name = name;
     }
     onAdded(entity) { }

--- a/lib/core/EntityManager.js
+++ b/lib/core/EntityManager.js
@@ -16,6 +16,9 @@ class EntityManager {
             const system = this.systemMap[component.name];
             if (system) {
                 system.onEntityAddedComponent(entity);
+                if (component.isNetworked) {
+                    system.addNetworkedFunctions(component);
+                }
             }
         };
         const oldRemoveComponent = entity.removeComponent;

--- a/lib/core/NetworkComponentDecorator.d.ts
+++ b/lib/core/NetworkComponentDecorator.d.ts
@@ -1,0 +1,2 @@
+import { Component } from "./Component";
+export declare function NetworkComponent(component: Component): Component;

--- a/lib/core/NetworkComponentDecorator.js
+++ b/lib/core/NetworkComponentDecorator.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function NetworkComponent(component) {
+    component.isNetworked = true;
+    return component;
+}
+exports.NetworkComponent = NetworkComponent;

--- a/lib/core/System/ClientSystem.d.ts
+++ b/lib/core/System/ClientSystem.d.ts
@@ -1,6 +1,7 @@
 import System from "./System";
 import { Message, MessageQueue } from '../MessageQueue';
 import { EntityManager } from "../EntityManager";
+import { Component } from "../Component";
 declare abstract class ClientSystem extends System {
     readonly name: string | number;
     private client;
@@ -22,6 +23,7 @@ declare abstract class ClientSystem extends System {
         [reference: string]: any;
     }): void;
     abstract onServerMessage(message: Message): any;
+    addNetworkedFunctions(component: Component): void;
     addListenStatePaths(path: string | Array<string>): void;
     onStateUpdate(pathString: any, pathData: any, change: any, value: any): void;
     onAreaWrite?(areaId: string | number, isInitial: boolean, options?: any): void;

--- a/lib/core/System/ClientSystem.js
+++ b/lib/core/System/ClientSystem.js
@@ -32,6 +32,11 @@ class ClientSystem extends System_1.default {
         this.initialized = true;
         this._onInit();
     }
+    addNetworkedFunctions(component) {
+        if (this.isNetworked) { // make sure client system is networked before binding
+            component.dispatchRemote = this.dispatchToServer.bind(this);
+        }
+    }
     addListenStatePaths(path) {
         if (Array.isArray(path)) {
             path.forEach(p => {

--- a/lib/core/System/ServerSystem.d.ts
+++ b/lib/core/System/ServerSystem.d.ts
@@ -1,4 +1,5 @@
 import System from "./System";
+import { Component } from "../Component";
 import { Message } from '../MessageQueue';
 import { ServerMessageQueue } from '../Server/ServerMessageQueue';
 import { EntityManager } from '../EntityManager';
@@ -10,6 +11,7 @@ declare abstract class ServerSystem extends System {
     initialize(messageQueue: ServerMessageQueue, entityManager: EntityManager, globalSystemVariables: {
         [reference: string]: any;
     }): void;
+    addNetworkedFunctions(component: Component): void;
     abstract onAreaMessage(areaId: any, message: any): any;
     abstract onClientMessage(client: any, message: any): any;
     dispatchToAreas(message: Message, toAreaIds?: Array<string>): void;

--- a/lib/core/System/ServerSystem.js
+++ b/lib/core/System/ServerSystem.js
@@ -19,6 +19,9 @@ class ServerSystem extends System_1.default {
         this.initialized = true;
         this._onInit();
     }
+    addNetworkedFunctions(component) {
+        component.dispatchRemote = this.dispatchToClient.bind(this, component.entityId);
+    }
     dispatchToAreas(message, toAreaIds) { }
     ;
     dispatchToClient(clientUid, message) { }

--- a/lib/core/System/System.d.ts
+++ b/lib/core/System/System.d.ts
@@ -1,6 +1,7 @@
 import { Message, MessageQueue } from '../MessageQueue';
 import { ServerMessageQueue } from '../Server/ServerMessageQueue';
 import { Entity } from '../Entity';
+import { Component } from '../Component';
 declare abstract class System {
     protected initialized: boolean;
     onRemoteMessage(message: Message): void;
@@ -23,6 +24,7 @@ declare abstract class System {
     abstract initialize(...args: any[]): void;
     abstract update(delta: any): void;
     abstract clear(): void;
+    protected abstract addNetworkedFunctions(component: Component): void;
     initializeEntity(entity: Entity, data?: any): void;
     destroyEntity(entity: Entity): void;
     onEntityRemovedComponent(entity: any): void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,4 +8,5 @@ export { ClientManager } from './core/ServerFrameworks/ClientManager';
 export { Entity } from './core/Entity';
 export { Component } from './core/Component';
 export { Client } from './core/WebClient/Client';
+export { NetworkComponent } from './core/NetworkComponentDecorator';
 export { Message } from './core/MessageQueue';

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,3 +16,5 @@ var Component_1 = require("./core/Component");
 exports.Component = Component_1.Component;
 var Client_2 = require("./core/WebClient/Client");
 exports.Client = Client_2.Client;
+var NetworkComponentDecorator_1 = require("./core/NetworkComponentDecorator");
+exports.NetworkComponent = NetworkComponentDecorator_1.NetworkComponent;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gotti",
-  "version": "0.2.5",
+  "version": "0.2.7",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "description": "Full stack scalable javascript and html5 game engine.",

--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -6,8 +6,14 @@ export abstract class Component {
     public name: string | number;
     public setAttribute: Function = () => {};
     public setAttributeGetter: Function = () => {};
+    public isNetworked: boolean;
 
-    constructor(name: string | number){
+    public dispatchRemote: Function = (message) => {};
+    public onRemote: Function = (message) => {};
+    public entityId: string | number;
+
+    constructor(name: string | number, isNetworked=false){
+        this.isNetworked = isNetworked;
         if (typeof(name) === 'undefined')
         {
             throw "Component: Invalid component name";
@@ -16,6 +22,7 @@ export abstract class Component {
         this.componentMethods = Object.getOwnPropertyNames(parentObj).filter(p => {
             return p !== "constructor" && p !== "prototype" && p !== 'onAdded' && p !== 'onRemoved'
         });
+        this.entityId = parentObj.id;
         this.name = name;
     }
     public onAdded(entity: Entity) {};

--- a/src/core/EntityManager.ts
+++ b/src/core/EntityManager.ts
@@ -26,6 +26,9 @@ export class EntityManager {
             const system = this.systemMap[component.name];
             if(system) {
                 system.onEntityAddedComponent(entity);
+                if(component.isNetworked) {
+                    system.addNetworkedFunctions(component);
+                }
             }
         };
 

--- a/src/core/NetworkComponentDecorator.ts
+++ b/src/core/NetworkComponentDecorator.ts
@@ -1,0 +1,6 @@
+import { Component } from "./Component";
+
+export function NetworkComponent(component: Component) {
+    component.isNetworked = true;
+    return component;
+}

--- a/src/core/System/ClientSystem.ts
+++ b/src/core/System/ClientSystem.ts
@@ -2,6 +2,7 @@ import System from "./System";
 import { Client as WebClient } from '../WebClient/Client';
 import { Message, MessageQueue } from '../MessageQueue';
 import {EntityManager} from "../EntityManager";
+import { Component } from "../Component";
 
 abstract class ClientSystem extends System {
     readonly name: string | number;
@@ -54,6 +55,12 @@ abstract class ClientSystem extends System {
     }
 
     public abstract onServerMessage(message: Message);
+
+    public addNetworkedFunctions(component: Component): void {
+        if(this.isNetworked) { // make sure client system is networked before binding
+            component.dispatchRemote = this.dispatchToServer.bind(this);
+        }
+    }
 
     public addListenStatePaths(path: string | Array<string>) {
         if (Array.isArray(path)) {

--- a/src/core/System/ServerSystem.ts
+++ b/src/core/System/ServerSystem.ts
@@ -1,4 +1,5 @@
 import System from "./System";
+import { Component } from "../Component";
 import { Client as WebClient } from '../WebClient/Client';
 import { Message } from '../MessageQueue';
 import { ServerMessageQueue } from '../Server/ServerMessageQueue';
@@ -36,6 +37,10 @@ abstract class ServerSystem extends System {
         this.initialized = true;
 
         this._onInit();
+    }
+
+    public addNetworkedFunctions(component: Component): void {
+        component.dispatchRemote = this.dispatchToClient.bind(this, component.entityId);
     }
 
     public abstract onAreaMessage(areaId, message);

--- a/src/core/System/System.ts
+++ b/src/core/System/System.ts
@@ -1,7 +1,7 @@
 import { Message, MessageQueue } from '../MessageQueue';
 import { ServerMessageQueue } from '../Server/ServerMessageQueue';
 import { Entity } from '../Entity';
-
+import { Component } from '../Component';
 abstract class System {
     protected initialized: boolean;
 
@@ -63,6 +63,8 @@ abstract class System {
 
     public abstract update (delta) : void;
     public abstract clear() : void;
+
+    protected abstract addNetworkedFunctions(component: Component) : void;
 
     //overrided in ServerSystem and ClientSystem initialize function
     public initializeEntity(entity:Entity, data?: any) {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,6 @@ export { ClientManager } from './core/ServerFrameworks/ClientManager';
 export { Entity } from './core/Entity';
 export { Component } from './core/Component';
 export {  Client } from './core/WebClient/Client';
+export { NetworkComponent } from './core/NetworkComponentDecorator';
 
 export { Message } from './core/MessageQueue';

--- a/test/core/Component.test.ts
+++ b/test/core/Component.test.ts
@@ -1,0 +1,32 @@
+import { Entity } from '../../src/core/Entity';
+import { Component } from '../../src/core/Component';
+import { NetworkComponent } from '../../src/core/NetworkComponentDecorator'
+import * as assert from 'assert';
+import * as mocha from 'mocha';
+import * as sinon from 'sinon';
+
+export class TestComponent extends Component {
+    public testProperty: number = 5;
+    constructor() {
+        super('TEST');
+        this.testProperty = 5;
+    }
+    testMethod() {
+        return this.testProperty;
+    }
+}
+
+describe('Component', function() {
+        it('Component isNetworking is false by default construction', (done) => {
+            const component = new TestComponent();
+            assert.ok(component);
+            assert.ok(!component.isNetworked);
+            done();
+        });
+        it('NetworkComponent decorator sets isNetworked to true', (done) => {
+            const component = NetworkComponent(new TestComponent());
+            assert.ok(component);
+            assert.ok(component.isNetworked);
+            done();
+        })
+});

--- a/test/core/EntityManager.test.ts
+++ b/test/core/EntityManager.test.ts
@@ -35,6 +35,11 @@ export class TestSystem extends System {
     initialize(...args: any[]): void {}
     onLocalMessage(message: any): void {}
     update(delta): void {}
+    addNetworkedFunctions(component: Component): void {
+        if(component.isNetworked) {
+            component.dispatchRemote = (message) => {};
+        }
+    }
 }
 
 describe('EntityManager', function() {


### PR DESCRIPTION
- for client the process must be networked
- you still handle messages in systems
- server components only work for players since it uses the dispatchToClient function, its meant for 1:1 communication, if you want to broadcast/dispatch all still do it in system 

```
 var component = new Component();
 component.dispatchRemote({type: MESSAGE, data: 1, to: [SYSTEM_NAME] )
```
code above will still execute but dispatchRemote is just an empty function so you can still use dispatchRemote in your components if its sometimes not networked, just make sure 
you're not expecting a response message from the server that is determined on the component dispatch.

```
var networkedComponent = NetworkComponent(new Component())
networkedComponent.({type: MESSAGE, data: 1, to: [SYSTEM_NAME] ) 
``` 
code above now actually dispatches the message and you can listen to the message either 
if you sent the message from a **client component**
still use onClientMessage() in your **server system** to handle 

if you sent the message from a **server component**
still use onServerMessage() in your **client system** to handle 
