### PR TITLE
Changed and added to NetworkedComponent api

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ It's mostly used by inheriting from the core base classes and implementing abstr
             this.x += dX;
             this.y += dY;
            
-            this.dispatchRemote({
+            this.sendRemote({
                 type: MESSAGES.CLIENT_POSITION_UPDATE,
                 to: [SYSTEM.POSITION],
                 data: [this.x, this.y]
@@ -113,13 +113,16 @@ It's mostly used by inheriting from the core base classes and implementing abstr
     // read more about setAttribute and setAttributeGetter in entity methods documentation
     // since theyre the same functions for whatever entity the component lives on
     
-    dispatchRemote(message) // { type, to, data, from? }
+    sendRemote(message) // { type, to, data, from? }
     // if component wrapped in NetworkedComponent and is on server it will send to the client of
     // whatever the component is attached to, so only use on server if its a component on a player entity 
     // or any entity where the id is the clientId of a client
     // if called on client it will dispatch normally and be retrieved on server normally
-    
+    sendRemoteImmediate(message) // exact same as above for server side until immediate messaging 
+                                 // is implemented, but client side we dispatch the message
+                                 // as soon as its called and not at the end of the loop
      
+    broadcastMessage(message) // only works on server side, will send message to all local clients
 #Entities
 ##Creating an Entity
 #### adding PositionComponent

--- a/lib/core/Component.d.ts
+++ b/lib/core/Component.d.ts
@@ -5,7 +5,9 @@ export declare abstract class Component {
     setAttribute: Function;
     setAttributeGetter: Function;
     isNetworked: boolean;
-    dispatchRemote: Function;
+    sendRemote: Function;
+    sendRemoteImmediate: Function;
+    broadcastRemote: Function;
     onRemote: Function;
     entityId: string | number;
     constructor(name: string | number, isNetworked?: boolean);

--- a/lib/core/Component.js
+++ b/lib/core/Component.js
@@ -6,7 +6,13 @@ class Component {
         this.componentMethods = [];
         this.setAttribute = () => { };
         this.setAttributeGetter = () => { };
-        this.dispatchRemote = (message) => { };
+        // sends message in timed send interval
+        this.sendRemote = (message) => { };
+        // sends message as soon as function is called
+        //TODO: no immediate from server to client yet will work same as sendRemote on server
+        this.sendRemoteImmediate = (message) => { };
+        // only works for server components
+        this.broadcastRemote = (message) => { };
         this.onRemote = (message) => { };
         this.isNetworked = isNetworked;
         if (typeof (name) === 'undefined') {

--- a/lib/core/NetworkComponentDecorator.d.ts
+++ b/lib/core/NetworkComponentDecorator.d.ts
@@ -1,2 +1,2 @@
 import { Component } from "./Component";
-export declare function NetworkComponent(component: Component): Component;
+export declare const NetworkComponent: (component: Component) => Component;

--- a/lib/core/NetworkComponentDecorator.js
+++ b/lib/core/NetworkComponentDecorator.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-function NetworkComponent(component) {
+exports.NetworkComponent = function NetworkComponent(component) {
     component.isNetworked = true;
     return component;
-}
-exports.NetworkComponent = NetworkComponent;
+};

--- a/lib/core/System/ClientSystem.js
+++ b/lib/core/System/ClientSystem.js
@@ -34,7 +34,10 @@ class ClientSystem extends System_1.default {
     }
     addNetworkedFunctions(component) {
         if (this.isNetworked) { // make sure client system is networked before binding
-            component.dispatchRemote = this.dispatchToServer.bind(this);
+            component.sendRemote = this.dispatchToServer.bind(this);
+            component.sendRemoteImmediate = this.immediateDispatchToServer.bind(this);
+            //client side components dont broadcast so just execute empty func if called
+            component.broadcastRemote = (message) => { };
         }
     }
     addListenStatePaths(path) {

--- a/lib/core/System/ServerSystem.js
+++ b/lib/core/System/ServerSystem.js
@@ -20,7 +20,9 @@ class ServerSystem extends System_1.default {
         this._onInit();
     }
     addNetworkedFunctions(component) {
-        component.dispatchRemote = this.dispatchToClient.bind(this, component.entityId);
+        component.sendRemote = this.dispatchToClient.bind(this, component.entityId);
+        component.sendRemoteImmediate = this.dispatchToClient.bind(this, component.entityId);
+        component.broadcastRemote = this.dispatchToLocalClients.bind(this);
     }
     dispatchToAreas(message, toAreaIds) { }
     ;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gotti",
-  "version": "0.2.7",
+  "version": "0.2.9",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "description": "Full stack scalable javascript and html5 game engine.",

--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -8,7 +8,15 @@ export abstract class Component {
     public setAttributeGetter: Function = () => {};
     public isNetworked: boolean;
 
-    public dispatchRemote: Function = (message) => {};
+    // sends message in timed send interval
+    public sendRemote: Function = (message) => {};
+    // sends message as soon as function is called
+    //TODO: no immediate from server to client yet will work same as sendRemote on server
+    public sendRemoteImmediate: Function = (message) => {};
+
+    // only works for server components
+    public broadcastRemote: Function = (message) => {};
+
     public onRemote: Function = (message) => {};
     public entityId: string | number;
 

--- a/src/core/NetworkComponentDecorator.ts
+++ b/src/core/NetworkComponentDecorator.ts
@@ -1,6 +1,6 @@
 import { Component } from "./Component";
 
-export function NetworkComponent(component: Component) {
+export const NetworkComponent = function NetworkComponent (component: Component){
     component.isNetworked = true;
     return component;
 }

--- a/src/core/System/ClientSystem.ts
+++ b/src/core/System/ClientSystem.ts
@@ -58,7 +58,10 @@ abstract class ClientSystem extends System {
 
     public addNetworkedFunctions(component: Component): void {
         if(this.isNetworked) { // make sure client system is networked before binding
-            component.dispatchRemote = this.dispatchToServer.bind(this);
+            component.sendRemote = this.dispatchToServer.bind(this);
+            component.sendRemoteImmediate = this.immediateDispatchToServer.bind(this);
+            //client side components dont broadcast so just execute empty func if called
+            component.broadcastRemote = (message) => {};
         }
     }
 

--- a/src/core/System/ServerSystem.ts
+++ b/src/core/System/ServerSystem.ts
@@ -40,7 +40,9 @@ abstract class ServerSystem extends System {
     }
 
     public addNetworkedFunctions(component: Component): void {
-        component.dispatchRemote = this.dispatchToClient.bind(this, component.entityId);
+        component.sendRemote = this.dispatchToClient.bind(this, component.entityId);
+        component.sendRemoteImmediate = this.dispatchToClient.bind(this, component.entityId);
+        component.broadcastRemote = this.dispatchToLocalClients.bind(this)
     }
 
     public abstract onAreaMessage(areaId, message);


### PR DESCRIPTION
**changed**
 - dispatchRemote -> sendRemote

**added**
- sendRemoteImmediate 
  - on client it will send as soon as its called instead of waiting at the end of the gameloop tick, server it functions same as sendRemote since theres no immediate remote dispatches yet on server
- broadcastRemote
  - does nothing on client components but server components will broadcast the message to all locally connected clients

